### PR TITLE
AW unique results

### DIFF
--- a/src/lib/policysearch.js
+++ b/src/lib/policysearch.js
@@ -16,14 +16,14 @@ export const policySearch = (keyword) => {
       'category'
     ]
   };
-  
-  let fuse = new Fuse(PolicyData, options);
+
+  const fuse = new Fuse(PolicyData, options);
   let finalResults = []
   let searchInputList = keyword.split(',').map(item => item.trim());
 
   searchInputList.forEach((keyword) => {
     const results = fuse.search(keyword);
-    finalResults = finalResults.concat(results);
+    finalResults = [...new Set(finalResults.concat(results))]; 
   })
 
   return finalResults;


### PR DESCRIPTION
* Fixed bug that allowed users to get repeat policies (ex. typing `ubi, freedom dividend`)
  * Solved this by using `Set` to ensure distinct results.